### PR TITLE
split spring test config and production and removed transaction management on dao layer

### DIFF
--- a/catacombs-chimeras-persistence/src/test/java/cz/muni/fi/PersistenceApplicationTestContext.java
+++ b/catacombs-chimeras-persistence/src/test/java/cz/muni/fi/PersistenceApplicationTestContext.java
@@ -1,6 +1,3 @@
-/**
- * @author Ondřej Benkovský
- */
 package cz.muni.fi;
 
 import org.hibernate.jpa.HibernatePersistenceProvider;
@@ -14,15 +11,20 @@ import org.springframework.instrument.classloading.InstrumentationLoadTimeWeaver
 import org.springframework.instrument.classloading.LoadTimeWeaver;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-
 @Configuration
+@EnableTransactionManagement
 @EnableJpaRepositories
 @ComponentScan(basePackages = "cz.muni.fi.dao")
-public class PersistenceApplicationContext {
+public class PersistenceApplicationTestContext {
 
     @Bean
     public PersistenceExceptionTranslationPostProcessor postProcessor() {
@@ -31,13 +33,33 @@ public class PersistenceApplicationContext {
 
     @Autowired
     @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory(final DataSource dataSource,
-                                                                       final LoadTimeWeaver loadTimeWeaver) {
+    public JpaTransactionManager transactionManager(final EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+
+    @Autowired
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource,
+                                                                       LoadTimeWeaver loadTimeWeaver,
+                                                                       HibernateJpaVendorAdapter hibernateJpaVendorAdapter) {
         LocalContainerEntityManagerFactoryBean jpaFactoryBean = new LocalContainerEntityManagerFactoryBean();
+        jpaFactoryBean.setPersistenceUnitName("test");
+        jpaFactoryBean.setJpaVendorAdapter(hibernateJpaVendorAdapter);
         jpaFactoryBean.setDataSource(dataSource);
         jpaFactoryBean.setLoadTimeWeaver(loadTimeWeaver);
         jpaFactoryBean.setPersistenceProviderClass(HibernatePersistenceProvider.class);
+        jpaFactoryBean.setPersistenceProvider(new HibernatePersistenceProvider());
+        jpaFactoryBean.setPackagesToScan("cz.muni.fi.entity");
         return jpaFactoryBean;
+    }
+
+    @Bean
+    public HibernateJpaVendorAdapter hibernateJpaVendorAdapter() {
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setDatabase(Database.DERBY);
+        vendorAdapter.setDatabasePlatform("org.hibernate.dialect.DerbyTenSevenDialect");
+        vendorAdapter.setGenerateDdl(true);
+        return vendorAdapter;
     }
 
     @Bean

--- a/catacombs-chimeras-persistence/src/test/java/cz/muni/fi/dao/RoleDaoTest.java
+++ b/catacombs-chimeras-persistence/src/test/java/cz/muni/fi/dao/RoleDaoTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 
-import cz.muni.fi.PersistenceApplicationContext;
+import cz.muni.fi.PersistenceApplicationTestContext;
 import cz.muni.fi.entity.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
@@ -28,7 +28,7 @@ import javax.validation.ConstraintViolationException;
 import java.util.List;
 
 
-@ContextConfiguration(classes=PersistenceApplicationContext.class)
+@ContextConfiguration(classes=PersistenceApplicationTestContext.class)
 @TestExecutionListeners(TransactionalTestExecutionListener.class)
 @Transactional
 public class RoleDaoTest extends AbstractTestNGSpringContextTests {


### PR DESCRIPTION
rozdelil jsem spring config na testovaci a na produkcni, jedina zmena co se vas opravdu dotkne je, ze v testech budete muset pouzit PersistenceApplicationTestContext. Take jsem oddelal transaction management na dao vrstve. Transaction management by se mel spravne provadet az na service vrstve :)  @Grez @DavidOsicka jestli nejsou zadne namitky, tak prosim merge :)